### PR TITLE
Optional props

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "babel": {
     "presets": "es2015"
   },
-  "dependencies": {
+  "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
     "jest": "^20.0.4",
     "prettier": "^1.5.3",
@@ -44,7 +44,7 @@
     "swig": "^1.4.2",
     "uglify-js": "^3.0.27"
   },
-  "peerDependencies": {
+  "dependencies": {
     "hyperapp": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "jest --no-cache",
     "compile": "rimraf dist && swig render -j vars.json src/html.* -o dist",
-    "bundle": "rollup -n hyperappHtml -f umd -g hyperapp:hyperapp -i dist/html.js -o dist/html.dist.js",
+    "bundle": "rollup -n hyperappHtml -f umd -i dist/html.js -o dist/html.dist.js",
     "minify": "uglifyjs dist/html.dist.js -o dist/html.dist.js --mangle --compress warnings=false --pure-funcs=Object.defineProperty -p relative --source-map dist/html.js.map",
     "build": "npm run compile && npm run bundle && npm run minify",
     "prepublish": "npm run build",
@@ -35,7 +35,7 @@
   "babel": {
     "presets": "es2015"
   },
-  "devDependencies": {
+  "dependencies": {
     "babel-preset-es2015": "^6.24.1",
     "jest": "^20.0.4",
     "prettier": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "jest --no-cache",
     "compile": "rimraf dist && swig render -j vars.json src/html.* -o dist",
-    "bundle": "rollup -n hyperappHtml -f umd -i dist/html.js -o dist/html.dist.js",
+    "bundle": "rollup -n hyperappHtml -f umd -g hyperapp:hyperapp -i dist/html.js -o dist/html.dist.js",
     "minify": "uglifyjs dist/html.dist.js -o dist/html.dist.js --mangle --compress warnings=false --pure-funcs=Object.defineProperty -p relative --source-map dist/html.js.map",
     "build": "npm run compile && npm run bundle && npm run minify",
     "prepublish": "npm run build",
@@ -44,7 +44,7 @@
     "swig": "^1.4.2",
     "uglify-js": "^3.0.27"
   },
-  "dependencies": {
+  "peerDependencies": {
     "hyperapp": "^0.11.0"
   }
 }

--- a/src/html.js
+++ b/src/html.js
@@ -1,8 +1,16 @@
 import { h } from "hyperapp"
 
+const hh = function (h) {
+  return function (tag, props, children) {
+    return typeof props === 'object' && !Array.isArray(props) && props !== null
+      ? h(tag, props, children)
+      : h(tag, null, props)
+  }
+}
+
 {% for tag in htmlTags %}
 export function {{ tag }}(props, children) {
-  return h("{{ tag }}", props, children)
+  return hh(h)("{{ tag }}", props, children)
 }
 {% endfor %}
 
@@ -10,7 +18,7 @@ export default function factory(h) {
   return {
     {% for tag in htmlTags %}
     {{ tag }}: function {{ tag }}(props, children) {
-      return h("{{ tag }}", props, children)
+      return hh(h)("{{ tag }}", props, children)
     }{% if !loop.last %},{% endif %}
     {% endfor %}
   }

--- a/src/html.js
+++ b/src/html.js
@@ -2,7 +2,7 @@ import { h } from "hyperapp"
 
 const hh = function (h) {
   return function (tag, props, children) {
-    return typeof props === 'object' && !Array.isArray(props) && props !== null
+    return typeof props === 'object' && !Array.isArray(props)
       ? h(tag, props, children)
       : h(tag, null, props)
   }

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -26,10 +26,17 @@ test("hyperapp h similarity", () => {
 })
 
 test("optional props", () => {
+
   expect(
     div()
   ).toEqual(
     h("div", null, [])
+  )
+
+  expect(
+    div(null, "Hi.")
+  ).toEqual(
+    h("div", null, "Hi.")
   )
 
   expect(
@@ -47,6 +54,7 @@ test("optional props", () => {
       h("h1", { id: "title" }, "Hi.")
     ])
   )
+
 })
 
 test("factory to use the right h", () => {

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -25,6 +25,30 @@ test("hyperapp h similarity", () => {
   )
 })
 
+test("optional props", () => {
+  expect(
+    div()
+  ).toEqual(
+    h("div", null, [])
+  )
+
+  expect(
+    div("Hi.")
+  ).toEqual(
+    h("div", null, ['Hi.'])
+  )
+
+  expect(
+    div([
+      h1({ id: "title" }, "Hi.")
+    ])
+  ).toEqual(
+    h("div", null, [
+      h("h1", { id: "title" }, "Hi.")
+    ])
+  )
+})
+
 test("factory to use the right h", () => {
   const h = jest.fn(
     (tag, props, children) => ({ tag, props, children })


### PR DESCRIPTION
This PR makes the the following statements equivalent: 
```
h('div', {}, 'hello')
div({}, 'hello')
div('hello')
```

We check to see if the first argument is a POJO (not null and not an array), if it is then the argument gets passed to `h` as `props`, if not then the argument gets passed to `h` as the `children` argument and `props` is set to `null`.

This seems too easy 😅 what did I miss?