### PR TITLE
Add overload for lazy components

### DIFF
--- a/src/html.d.ts
+++ b/src/html.d.ts
@@ -7,11 +7,14 @@ import { VNode } from "hyperapp"
  * @param attributes Any valid HTML atributes, events, styles, and meta data
  * @param children   The VNode children
  */
+export function {{ name }}<State = {}, Actions = {}>(
+  ...params: any
+): (state: State, actions: Actions) => VNode<{}>
 export function {{ name }}<Attributes = {}>(
   attributes?: Attributes,
-  children?: string | number | Array<string | number | VNode<{}>>
+  children?: string | number | VNode<{}> | Array<string | number | VNode<{}>>
 ): VNode<Attributes>
 export function {{ name }}(
-  children?: string | number | Array<string | number | VNode<{}>>
+  children?: string | number | VNode<{}> | Array<string | number | VNode<{}>>
 ): VNode<{}>
 {% endfor %}

--- a/src/html.d.ts
+++ b/src/html.d.ts
@@ -7,14 +7,14 @@ import { VNode } from "hyperapp"
  * @param attributes Any valid HTML atributes, events, styles, and meta data
  * @param children   The VNode children
  */
-export function {{ name }}<State = {}, Actions = {}>(
-  ...params: any
-): (state: State, actions: Actions) => VNode<{}>
+export function {{ name }}(
+  children?: string | number | VNode<{}> | Array<string | number | VNode<{}>>
+): VNode<{}>
 export function {{ name }}<Attributes = {}>(
   attributes?: Attributes,
   children?: string | number | VNode<{}> | Array<string | number | VNode<{}>>
 ): VNode<Attributes>
-export function {{ name }}(
-  children?: string | number | VNode<{}> | Array<string | number | VNode<{}>>
-): VNode<{}>
+export function {{ name }}<State = {}, Actions = {}>(
+  ...params: any
+): (state: State, actions: Actions) => VNode<{}>
 {% endfor %}


### PR DESCRIPTION
hyperapp v1 allows creating lazy components which are curried functions receiving `state` and `actions` as arguments. this adds a third overload allowing the usage of lazy components.

It also allows passing just one `VNode<{}>` as `children`, since that is possible as well.